### PR TITLE
CID-2824: fix cache expiry duration

### DIFF
--- a/src/main/kotlin/net/leanix/githubagent/services/CachingService.kt
+++ b/src/main/kotlin/net/leanix/githubagent/services/CachingService.kt
@@ -22,7 +22,7 @@ class CachingService(
                 value: CacheValue,
                 currentTime: Long
             ): Long {
-                return value.expiry ?: Long.MAX_VALUE
+                return value.expiry?.times(1_000_000_000) ?: Long.MAX_VALUE
             }
 
             override fun expireAfterUpdate(
@@ -31,7 +31,7 @@ class CachingService(
                 currentTime: Long,
                 currentDuration: Long
             ): Long {
-                return value.expiry ?: Long.MAX_VALUE
+                return value.expiry?.times(1_000_000_000) ?: Long.MAX_VALUE
             }
 
             override fun expireAfterRead(


### PR DESCRIPTION
## 🛠 Changes made
Updated the expiry duration when setting cache entries.
Caffeine uses nanoseconds by default, so we need to adapt the expiry durations passed to the builder to convert seconds to nanoseconds

## ✨ Type of change
Please delete the options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## 🧪 How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
- [x] 🚨 No tests Deployed