### PR TITLE
CID-2862: Create a separate GH action to release dev docker image

### DIFF
--- a/.github/workflows/release-dev-docker-image.yml
+++ b/.github/workflows/release-dev-docker-image.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - "feature/**"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## 🛠 Changes made
Adding a GitHub action to release a dev Docker image

## 🧪 How Has This Been Tested?
- [x] No tests required

## 🏎 Checklist:
- [x] I have performed a self-review of my own code
- [x] My commit message clearly reflects the changes made
- [x] Assigned the appropriate labels (version, PR type, etc.)