### PR TITLE
CID-3018: Modify repositories full scan to no send manifest content

### DIFF
--- a/src/main/kotlin/net/leanix/githubagent/dto/RepositoryDto.kt
+++ b/src/main/kotlin/net/leanix/githubagent/dto/RepositoryDto.kt
@@ -13,5 +13,4 @@ data class RepositoryDto(
     val updatedAt: String,
     val languages: List<String>,
     val topics: List<String>,
-    val manifestFileContent: String?,
 )

--- a/src/main/kotlin/net/leanix/githubagent/services/GitHubGraphQLService.kt
+++ b/src/main/kotlin/net/leanix/githubagent/services/GitHubGraphQLService.kt
@@ -8,7 +8,6 @@ import net.leanix.githubagent.dto.RepositoryDto
 import net.leanix.githubagent.exceptions.GraphQLApiException
 import net.leanix.githubagent.graphql.data.GetRepositories
 import net.leanix.githubagent.graphql.data.GetRepositoryManifestContent
-import net.leanix.githubagent.graphql.data.getrepositories.Blob
 import net.leanix.githubagent.shared.ManifestFileName
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -62,13 +61,6 @@ class GitHubGraphQLService(
                         updatedAt = it.updatedAt,
                         languages = it.languages!!.nodes!!.map { language -> language!!.name },
                         topics = it.repositoryTopics.nodes!!.map { topic -> topic!!.topic.name },
-                        manifestFileContent = if (it.manifestYaml != null) {
-                            (it.manifestYaml as Blob).text.toString()
-                        } else if (it.manifestYml != null) {
-                            (it.manifestYml as Blob).text.toString()
-                        } else {
-                            null
-                        }
                     )
                 }
             )

--- a/src/main/resources/graphql/GetRepositories.graphql
+++ b/src/main/resources/graphql/GetRepositories.graphql
@@ -16,28 +16,16 @@ query GetRepositories($pageCount: Int!, $cursor: String, $manifestYamlPath: Stri
                 owner{
                     login
                 }
-                languages(first: 10) {
+                languages(first: 25) {
                     nodes {
                         name
                     }
                 }
-                repositoryTopics(first:10) {
+                repositoryTopics(first:25) {
                     nodes {
                         topic {
                             name
                         }
-                    }
-                }
-                manifestYaml: object(expression: $manifestYamlPath) {
-                    __typename
-                    ... on Blob {
-                        text
-                    }
-                }
-                manifestYml: object(expression: $manifestYmlPath) {
-                    __typename
-                    ... on Blob {
-                        text
                     }
                 }
             }

--- a/src/test/kotlin/net/leanix/githubagent/services/GitHubScanningServiceTest.kt
+++ b/src/test/kotlin/net/leanix/githubagent/services/GitHubScanningServiceTest.kt
@@ -98,7 +98,6 @@ class GitHubScanningServiceTest {
                     updatedAt = "2024-01-01T00:00:00Z",
                     languages = listOf("Kotlin", "Java"),
                     topics = listOf("test", "example"),
-                    manifestFileContent = "content"
                 )
             ),
             hasNextPage = false,


### PR DESCRIPTION
## 🛠 Changes made
In order to support discovering multiple manifest files within a repository, this PR modifies the repositoryDto in full scan to no send manifest content.

## ✨ Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## 🧪 How Has This Been Tested?
- [x] Test adapted

## 🏎 Checklist:
- [x] My code follows the style guidelines
- [x] I have performed a self-review of my own code
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My commit message clearly reflects the changes made
- [x] Assigned the appropriate labels (version, PR type, etc.)