### PR TITLE
CID-3000: Switch from app name to slug

### DIFF
--- a/src/main/kotlin/net/leanix/githubagent/dto/GitHubAppResponse.kt
+++ b/src/main/kotlin/net/leanix/githubagent/dto/GitHubAppResponse.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class GitHubAppResponse(
-    @JsonProperty("name") val name: String,
+    @JsonProperty("slug") val slug: String,
     @JsonProperty("permissions") val permissions: Map<String, String>,
     @JsonProperty("events") val events: List<String>
 )

--- a/src/main/kotlin/net/leanix/githubagent/runners/PostStartupRunner.kt
+++ b/src/main/kotlin/net/leanix/githubagent/runners/PostStartupRunner.kt
@@ -36,7 +36,7 @@ class PostStartupRunner(
         val jwt = cachingService.get("jwtToken") as String
         webSocketService.sendMessage(
             APP_NAME_TOPIC,
-            gitHubEnterpriseService.getGitHubApp(jwt).name
+            gitHubEnterpriseService.getGitHubApp(jwt).slug
         )
         gitHubScanningService.scanGitHubResources()
     }

--- a/src/main/kotlin/net/leanix/githubagent/services/GitHubEnterpriseService.kt
+++ b/src/main/kotlin/net/leanix/githubagent/services/GitHubEnterpriseService.kt
@@ -20,7 +20,7 @@ class GitHubEnterpriseService(private val githubClient: GitHubClient) {
         runCatching {
             val githubApp = getGitHubApp(jwt)
             validateGithubAppResponse(githubApp)
-            logger.info("Authenticated as GitHub App: '${githubApp.name}'")
+            logger.info("Authenticated as GitHub App: '${githubApp.slug}'")
         }.onFailure {
             logger.error("Failed to verify JWT token", it)
             when (it) {

--- a/src/test/kotlin/net/leanix/githubagent/services/GitHubEnterpriseServiceTest.kt
+++ b/src/test/kotlin/net/leanix/githubagent/services/GitHubEnterpriseServiceTest.kt
@@ -19,7 +19,7 @@ class GitHubEnterpriseServiceTest {
     fun `verifyJwt with valid jwt should not throw exception`() {
         val jwt = "validJwt"
         val githubApp = GitHubAppResponse(
-            name = "validApp",
+            slug = "validApp",
             permissions = mapOf("administration" to "read", "contents" to "read", "metadata" to "read"),
             events = listOf("label", "public", "repository")
         )
@@ -39,7 +39,7 @@ class GitHubEnterpriseServiceTest {
     @Test
     fun `validateGithubAppResponse with correct permissions should not throw exception`() {
         val response = GitHubAppResponse(
-            name = "validApp",
+            slug = "validApp",
             permissions = mapOf("administration" to "read", "contents" to "read", "metadata" to "read"),
             events = listOf("label", "public", "repository")
         )
@@ -50,7 +50,7 @@ class GitHubEnterpriseServiceTest {
     @Test
     fun `validateGithubAppResponse with missing permissions should throw exception`() {
         val response = GitHubAppResponse(
-            name = "validApp",
+            slug = "validApp",
             permissions = mapOf("administration" to "read", "contents" to "read"),
             events = listOf("label", "public", "repository")
         )
@@ -63,7 +63,7 @@ class GitHubEnterpriseServiceTest {
     @Test
     fun `validateGithubAppResponse with missing events should throw exception`() {
         val response = GitHubAppResponse(
-            name = "validApp",
+            slug = "validApp",
             permissions = mapOf("administration" to "read", "contents" to "read", "metadata" to "read"),
             events = listOf("label", "public")
         )


### PR DESCRIPTION
## 🛠 Changes made
If the GitHub App name includes special characters, GitHub encodes it in way that is unknown for us. Hence, the agent need to send the GitHub App slug instead of name.

## ✨ Type of change
Please delete the options that are not relevant.

## 🧪 How Has This Been Tested?
- [x] 👌 No tests required

## 🏎 Checklist:
- [x] My code follows the style guidelines
- [x] I have performed a self-review of my own code
- [x] My commit message clearly reflects the changes made
- [x] Assigned the appropriate labels (version, PR type, etc.)