### PR TITLE
CID-3159: Use yaml as manifest extension

### DIFF
--- a/src/main/kotlin/net/leanix/githubagent/shared/Constants.kt
+++ b/src/main/kotlin/net/leanix/githubagent/shared/Constants.kt
@@ -3,7 +3,7 @@ package net.leanix.githubagent.shared
 const val TOPIC_PREFIX = "/app/ghe/"
 const val APP_NAME_TOPIC = "appName"
 const val LOGS_TOPIC = "logs"
-const val MANIFEST_FILE_NAME = "leanix.yml"
+const val MANIFEST_FILE_NAME = "leanix.yaml"
 
 val SUPPORTED_EVENT_TYPES = listOf(
     "REPOSITORY",

--- a/src/test/kotlin/net/leanix/githubagent/services/WebhookEventServiceTest.kt
+++ b/src/test/kotlin/net/leanix/githubagent/services/WebhookEventServiceTest.kt
@@ -301,4 +301,37 @@ class WebhookEventServiceTest {
             )
         }
     }
+
+    @Test
+    fun `should not handle push event with unsupported YAML extension`() {
+        val payload = """{
+            "repository": {
+                "name": "repo",
+                "full_name": "owner/repo",
+                "owner": {"name": "owner"},
+                "default_branch": "main"
+            },
+            "head_commit": {
+                "added": ["custom/path/added1/$UNSUPPORTED_MANIFEST_EXTENSION"],
+                "modified": [],
+                "removed": []
+            },
+            "installation": {"id": 1},
+            "ref": "refs/heads/main"
+        }"""
+
+        webhookEventService.consumeWebhookEvent("PUSH", payload)
+
+        verify(exactly = 0) {
+            webSocketService.sendMessage(
+                "/events/manifestFile",
+                ManifestFileUpdateDto(
+                    "owner/repo",
+                    ManifestFileAction.ADDED,
+                    "content",
+                    "custom/path/added1/$MANIFEST_FILE_NAME"
+                )
+            )
+        }
+    }
 }

--- a/src/test/kotlin/net/leanix/githubagent/services/WebhookEventServiceTest.kt
+++ b/src/test/kotlin/net/leanix/githubagent/services/WebhookEventServiceTest.kt
@@ -270,7 +270,7 @@ class WebhookEventServiceTest {
     }
 
     @Test
-    fun `should handle push event with supported YAML extension`() {
+    fun `should handle push event only with supported YAML extension`() {
         val payload = """{
             "repository": {
                 "name": "repo",
@@ -300,27 +300,6 @@ class WebhookEventServiceTest {
                 )
             )
         }
-    }
-
-    @Test
-    fun `should not handle push event with unsupported YAML extension`() {
-        val payload = """{
-            "repository": {
-                "name": "repo",
-                "full_name": "owner/repo",
-                "owner": {"name": "owner"},
-                "default_branch": "main"
-            },
-            "head_commit": {
-                "added": ["custom/path/added1/$UNSUPPORTED_MANIFEST_EXTENSION"],
-                "modified": [],
-                "removed": []
-            },
-            "installation": {"id": 1},
-            "ref": "refs/heads/main"
-        }"""
-
-        webhookEventService.consumeWebhookEvent("PUSH", payload)
 
         verify(exactly = 0) {
             webSocketService.sendMessage(
@@ -329,7 +308,7 @@ class WebhookEventServiceTest {
                     "owner/repo",
                     ManifestFileAction.ADDED,
                     "content",
-                    "custom/path/added1/$MANIFEST_FILE_NAME"
+                    "custom/path/added1/$UNSUPPORTED_MANIFEST_EXTENSION"
                 )
             )
         }

--- a/src/test/kotlin/net/leanix/githubagent/services/WebhookEventServiceTest.kt
+++ b/src/test/kotlin/net/leanix/githubagent/services/WebhookEventServiceTest.kt
@@ -279,7 +279,7 @@ class WebhookEventServiceTest {
                 "default_branch": "main"
             },
             "head_commit": {
-                "added": ["custom/path/added1/leanix.yml", "custom/path/added2/$MANIFEST_FILE_NAME"],
+                "added": ["custom/path/added1/$UNSUPPORTED_MANIFEST_EXTENSION", "custom/path/added2/$MANIFEST_FILE_NAME"],
                 "modified": [],
                 "removed": []
             },


### PR DESCRIPTION
- Instead of yml use yaml as the officially supported manifest extension

## 🛠 Changes made
The manifest file extension should be `yaml` instead of `yml`

## ✨ Type of change
Please delete the options that are not relevant.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## 🧪 How Has This Been Tested?
Please describe the tests that you ran to verify your changes.

- [ ] Change the manifest file extension to `yaml`, the file should be processed
- [ ] Change the manifest file extension to `yml`, the file should be ignored

## 🏎 Checklist:
- [x] My code follows the style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My commit message clearly reflects the changes made
- [x] Assigned the appropriate labels (version, PR type, etc.)