### PR TITLE
cid-3158: Remove filename when file is in the root

### DIFF
--- a/src/main/kotlin/net/leanix/githubagent/services/GitHubScanningService.kt
+++ b/src/main/kotlin/net/leanix/githubagent/services/GitHubScanningService.kt
@@ -26,6 +26,7 @@ class GitHubScanningService(
     private val gitHubAuthenticationService: GitHubAuthenticationService,
     private val syncLogService: SyncLogService
 ) {
+    val removeFileNameRegex = Regex("/?$MANIFEST_FILE_NAME\$")
 
     private val logger = LoggerFactory.getLogger(GitHubScanningService::class.java)
 
@@ -163,7 +164,7 @@ class GitHubScanningService(
                 numOfManifestFilesFound++
                 syncLogService.sendInfoLog("Fetched manifest file ${manifestFile.path} from repository $repositoryName")
                 ManifestFileDTO(
-                    path = manifestFile.path.replace("/$MANIFEST_FILE_NAME", ""),
+                    path = removeFileNameRegex.replace(manifestFile.path, ""),
                     content = content
                 )
             } else {


### PR DESCRIPTION
## 🛠 Changes made
Remove the manifest file name when the file is in the root directory

## ✨ Type of change
Please delete the options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 🧪 How Has This Been Tested?
- [ ] Test added


## 🏎 Checklist:
- [ ] My code follows the style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have made corresponding changes to the documentation (README.md)
- [ ] My commit message clearly reflects the changes made
- [ ] Assigned the appropriate labels (version, PR type, etc.)