### PR TITLE
cid-31656: Remove the name of the file on the webhook events

### DIFF
--- a/src/main/kotlin/net/leanix/githubagent/services/GitHubScanningService.kt
+++ b/src/main/kotlin/net/leanix/githubagent/services/GitHubScanningService.kt
@@ -13,6 +13,7 @@ import net.leanix.githubagent.dto.Trigger
 import net.leanix.githubagent.exceptions.JwtTokenNotFound
 import net.leanix.githubagent.exceptions.ManifestFileNotFoundException
 import net.leanix.githubagent.shared.MANIFEST_FILE_NAME
+import net.leanix.githubagent.shared.fileNameMatchRegex
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.util.UUID
@@ -26,7 +27,6 @@ class GitHubScanningService(
     private val gitHubAuthenticationService: GitHubAuthenticationService,
     private val syncLogService: SyncLogService
 ) {
-    val fileNameMatchRegex = Regex("/?$MANIFEST_FILE_NAME\$")
 
     private val logger = LoggerFactory.getLogger(GitHubScanningService::class.java)
 

--- a/src/main/kotlin/net/leanix/githubagent/services/WebhookEventService.kt
+++ b/src/main/kotlin/net/leanix/githubagent/services/WebhookEventService.kt
@@ -7,6 +7,7 @@ import net.leanix.githubagent.dto.ManifestFileUpdateDto
 import net.leanix.githubagent.dto.PushEventCommit
 import net.leanix.githubagent.dto.PushEventPayload
 import net.leanix.githubagent.shared.MANIFEST_FILE_NAME
+import net.leanix.githubagent.shared.fileNameMatchRegex
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -124,7 +125,7 @@ class WebhookEventService(
                 repositoryFullName,
                 action,
                 fileContent,
-                manifestFilePath
+                fileNameMatchRegex.replace(manifestFilePath, "")
             )
         )
     }
@@ -138,7 +139,7 @@ class WebhookEventService(
                 repositoryFullName,
                 ManifestFileAction.REMOVED,
                 null,
-                manifestFilePath
+                fileNameMatchRegex.replace(manifestFilePath, "")
             )
         )
     }

--- a/src/main/kotlin/net/leanix/githubagent/shared/Constants.kt
+++ b/src/main/kotlin/net/leanix/githubagent/shared/Constants.kt
@@ -11,3 +11,5 @@ val SUPPORTED_EVENT_TYPES = listOf(
     "ORGANIZATION",
     "INSTALLATION",
 )
+
+val fileNameMatchRegex = Regex("/?$MANIFEST_FILE_NAME\$")

--- a/src/test/kotlin/net/leanix/githubagent/services/WebhookEventServiceTest.kt
+++ b/src/test/kotlin/net/leanix/githubagent/services/WebhookEventServiceTest.kt
@@ -93,7 +93,7 @@ class WebhookEventServiceTest {
                     "owner/repo",
                     ManifestFileAction.MODIFIED,
                     "content",
-                    MANIFEST_FILE_NAME
+                    ""
                 )
             )
         }
@@ -179,7 +179,7 @@ class WebhookEventServiceTest {
                     "owner/repo",
                     ManifestFileAction.REMOVED,
                     null,
-                    "a/b/c/$MANIFEST_FILE_NAME"
+                    "a/b/c"
                 )
             )
         }
@@ -212,7 +212,7 @@ class WebhookEventServiceTest {
                     "owner/repo",
                     ManifestFileAction.ADDED,
                     "content",
-                    "a/b/c/$MANIFEST_FILE_NAME"
+                    "a/b/c"
                 )
             )
         }
@@ -245,7 +245,7 @@ class WebhookEventServiceTest {
                     "owner/repo",
                     ManifestFileAction.ADDED,
                     "content",
-                    "custom/path/added1/$MANIFEST_FILE_NAME"
+                    "custom/path/added1"
                 )
             )
             webSocketService.sendMessage(
@@ -254,7 +254,7 @@ class WebhookEventServiceTest {
                     "owner/repo",
                     ManifestFileAction.ADDED,
                     "content",
-                    "custom/path/added2/$MANIFEST_FILE_NAME"
+                    "custom/path/added2"
                 )
             )
             webSocketService.sendMessage(
@@ -263,7 +263,7 @@ class WebhookEventServiceTest {
                     "owner/repo",
                     ManifestFileAction.MODIFIED,
                     "content",
-                    "custom/path/modified/$MANIFEST_FILE_NAME"
+                    "custom/path/modified"
                 )
             )
         }
@@ -296,7 +296,7 @@ class WebhookEventServiceTest {
                     "owner/repo",
                     ManifestFileAction.ADDED,
                     "content",
-                    "custom/path/added2/$MANIFEST_FILE_NAME"
+                    "custom/path/added2"
                 )
             )
         }


### PR DESCRIPTION
## 🛠 Changes made
Remove the filename on the manifest file webhook events

## ✨ Type of change
Please delete the options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## 🧪 How Has This Been Tested?

- [x] Tests modified


## 🏎 Checklist:
- [x] My code follows the style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My commit message clearly reflects the changes made
- [x] Assigned the appropriate labels (version, PR type, etc.)