### PR TITLE
CID-2940 Use 5 max attempts for retrying establishing connection

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -27,7 +27,7 @@ style:
   ReturnCount:
     active: false
   UnusedPrivateMember:
-    active: false
+    active: true
   ThrowsCount:
     active: false
 

--- a/src/main/kotlin/net/leanix/githubagent/config/WebSocketClientConfig.kt
+++ b/src/main/kotlin/net/leanix/githubagent/config/WebSocketClientConfig.kt
@@ -3,7 +3,6 @@ package net.leanix.githubagent.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.github.resilience4j.retry.annotation.Retry
 import net.leanix.githubagent.handler.BrokerStompSessionHandler
-import net.leanix.githubagent.services.LeanIXAuthService
 import net.leanix.githubagent.shared.GitHubAgentProperties.GITHUB_AGENT_VERSION
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -21,17 +20,14 @@ import org.springframework.web.socket.sockjs.client.WebSocketTransport
 class WebSocketClientConfig(
     private val brokerStompSessionHandler: BrokerStompSessionHandler,
     private val objectMapper: ObjectMapper,
-    private val leanIXAuthService: LeanIXAuthService,
-    private val leanIXProperties: LeanIXProperties,
-    private val gitHubEnterpriseProperties: GitHubEnterpriseProperties
+    private val leanIXProperties: LeanIXProperties
 ) {
-
-    @Retry(name = "ws-init-session")
+    @Retry(name = "ws_init_session")
     fun initSession(): StompSession {
         val headers = WebSocketHttpHeaders()
         val stompHeaders = StompHeaders()
-        stompHeaders["Authorization"] = "Bearer ${leanIXAuthService.getBearerToken()}"
-        stompHeaders["GitHub-Enterprise-URL"] = gitHubEnterpriseProperties.baseUrl
+        stompHeaders["Authorization"] = "Bearer dummy"
+        stompHeaders["GitHub-Enterprise-URL"] = "https://url.com"
         stompHeaders["GitHub-Agent-Version"] = GITHUB_AGENT_VERSION
         return stompClient().connectAsync(
             leanIXProperties.wsBaseUrl,

--- a/src/main/kotlin/net/leanix/githubagent/config/WebSocketClientConfig.kt
+++ b/src/main/kotlin/net/leanix/githubagent/config/WebSocketClientConfig.kt
@@ -3,6 +3,7 @@ package net.leanix.githubagent.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.github.resilience4j.retry.annotation.Retry
 import net.leanix.githubagent.handler.BrokerStompSessionHandler
+import net.leanix.githubagent.services.LeanIXAuthService
 import net.leanix.githubagent.shared.GitHubAgentProperties.GITHUB_AGENT_VERSION
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -20,14 +21,16 @@ import org.springframework.web.socket.sockjs.client.WebSocketTransport
 class WebSocketClientConfig(
     private val brokerStompSessionHandler: BrokerStompSessionHandler,
     private val objectMapper: ObjectMapper,
-    private val leanIXProperties: LeanIXProperties
+    private val leanIXAuthService: LeanIXAuthService,
+    private val leanIXProperties: LeanIXProperties,
+    private val gitHubEnterpriseProperties: GitHubEnterpriseProperties
 ) {
     @Retry(name = "ws_init_session")
     fun initSession(): StompSession {
         val headers = WebSocketHttpHeaders()
         val stompHeaders = StompHeaders()
-        stompHeaders["Authorization"] = "Bearer dummy"
-        stompHeaders["GitHub-Enterprise-URL"] = "https://url.com"
+        stompHeaders["Authorization"] = "Bearer ${leanIXAuthService.getBearerToken()}"
+        stompHeaders["GitHub-Enterprise-URL"] = gitHubEnterpriseProperties.baseUrl
         stompHeaders["GitHub-Agent-Version"] = GITHUB_AGENT_VERSION
         return stompClient().connectAsync(
             leanIXProperties.wsBaseUrl,

--- a/src/main/kotlin/net/leanix/githubagent/services/CachingService.kt
+++ b/src/main/kotlin/net/leanix/githubagent/services/CachingService.kt
@@ -58,6 +58,7 @@ class CachingService(
     }
 
     @PostConstruct
+    @Suppress("UnusedPrivateMember")
     private fun init() {
         set("baseUrl", gitHubEnterpriseProperties.baseUrl, null)
         set("githubAppId", gitHubEnterpriseProperties.gitHubAppId, null)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,5 +16,8 @@ webhookEventService:
 resilience4j.retry:
   configs:
     default:
-      maxAttempts: 3
+      maxAttempts: 5
+      enable-exponential-backoff: true
+      exponential-backoff-multiplier: 2
       waitDuration: 1000
+

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,3 +10,9 @@ leanix:
   auth:
     access-token-uri: ${leanix.base-url}/mtm/v1
     technical-user-token: ${LEANIX_TECHNICAL_USER_TOKEN}
+
+resilience4j.retry:
+  configs:
+    default:
+      maxAttempts: 3
+      waitDuration: 1000

--- a/src/test/kotlin/net/leanix/githubagent/config/WebSocketClientConfigTests.kt
+++ b/src/test/kotlin/net/leanix/githubagent/config/WebSocketClientConfigTests.kt
@@ -1,51 +1,57 @@
 package net.leanix.githubagent.config
 
-// class WebSocketClientConfigTests {
-//
-//    private lateinit var webSocketClientConfig: WebSocketClientConfig
-//    private val authService: AuthService = mockk()
-//    private val stompClient: WebSocketStompClient = mockk(relaxed = true)
-//    private val stompSession: StompSession = mockk(relaxed = true)
-//    private val brokerStompSessionHandler: BrokerStompSessionHandler = mockk(relaxed = true)
-//    private val objectMapper: ObjectMapper = mockk(relaxed = true)
-//    private val leanIXProperties: LeanIXProperties = mockk(relaxed = true)
-//    private val gitHubEnterpriseProperties: GitHubEnterpriseProperties = mockk(relaxed = true)
-//
-//    @BeforeEach
-//    fun setUp() {
-//        webSocketClientConfig = WebSocketClientConfig(
-//            brokerStompSessionHandler,
-//            objectMapper,
-//            authService,
-//            leanIXProperties,
-//            gitHubEnterpriseProperties
-//        )
-//        webSocketClientConfig.stompClient = stompClient
-//    }
-//
-//    @Test
-//    fun `initSession should establish connection with valid headers`() = runBlocking {
-//        coEvery { authService.getBearerToken() } returns "validToken"
-//        coEvery { leanIXProperties.wsBaseUrl } returns "ws://test.url"
-//        coEvery { gitHubEnterpriseProperties.baseUrl } returns "http://github.enterprise.url"
-//        coEvery { gitHubEnterpriseProperties.gitHubAppId } returns "appId"
-//        coEvery { stompClient.connect(any(), any(), any(), any()) } returns stompSession
-//
-//        val session = webSocketClientConfig.initSession()
-//
-//        assertEquals(stompSession, session)
-//    }
-//
-//    @Test
-//    fun `initSession should handle connection failure gracefully`() = runBlocking {
-//        coEvery { authService.getBearerToken() } returns "validToken"
-//        coEvery { leanIXProperties.wsBaseUrl } returns "ws://test.url"
-//        coEvery { gitHubEnterpriseProperties.baseUrl } returns "http://github.enterprise.url"
-//        coEvery { gitHubEnterpriseProperties.gitHubAppId } returns "appId"
-//        coEvery { stompClient.connect(any(), any(), any(), any()) } throws RuntimeException("Connection failed")
-//
-//        val session = runCatching { webSocketClientConfig.initSession() }.getOrNull()
-//
-//        assertEquals(null, session)
-//    }
-// }
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import net.leanix.githubagent.handler.BrokerStompSessionHandler
+import net.leanix.githubagent.services.LeanIXAuthService
+import net.leanix.githubagent.shared.GitHubAgentProperties
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.messaging.simp.stomp.StompHeaders
+import org.springframework.messaging.simp.stomp.StompSession
+import org.springframework.web.socket.WebSocketHttpHeaders
+import org.springframework.web.socket.messaging.WebSocketStompClient
+
+class WebSocketClientConfigTests {
+    private lateinit var webSocketClientConfig: WebSocketClientConfig
+    private lateinit var stompClient: WebSocketStompClient
+    private lateinit var stompSession: StompSession
+    private lateinit var authService: LeanIXAuthService
+    private lateinit var leanIXProperties: LeanIXProperties
+    private lateinit var gitHubEnterpriseProperties: GitHubEnterpriseProperties
+
+    @BeforeEach
+    fun setUp() {
+        val brokerStompSessionHandler = mockk<BrokerStompSessionHandler>()
+        val objectMapper = mockk<ObjectMapper>()
+        leanIXProperties = mockk()
+        gitHubEnterpriseProperties = mockk()
+        stompClient = mockk()
+        stompSession = mockk()
+        authService = mockk()
+        webSocketClientConfig = WebSocketClientConfig(brokerStompSessionHandler, objectMapper, leanIXProperties)
+
+        GitHubAgentProperties.GITHUB_AGENT_VERSION = "test-version"
+    }
+
+    @Test
+    fun `initSession should fail after max retry attempts`() = runBlocking {
+        coEvery { authService.getBearerToken() } returns "validToken"
+        coEvery { leanIXProperties.wsBaseUrl } returns "ws://test.url"
+        coEvery { gitHubEnterpriseProperties.baseUrl } returns "http://github.enterprise.url"
+        coEvery { gitHubEnterpriseProperties.gitHubAppId } returns "appId"
+        coEvery {
+            stompClient.connectAsync(
+                any<String>(), any<WebSocketHttpHeaders>(),
+                any<StompHeaders>(), any<BrokerStompSessionHandler>()
+            )
+        } throws RuntimeException("Connection failed")
+
+        val session = runCatching { webSocketClientConfig.initSession() }.getOrNull()
+
+        assertEquals(null, session)
+    }
+}

--- a/src/test/kotlin/net/leanix/githubagent/config/WebSocketClientConfigTests.kt
+++ b/src/test/kotlin/net/leanix/githubagent/config/WebSocketClientConfigTests.kt
@@ -22,6 +22,7 @@ class WebSocketClientConfigTests {
     private lateinit var authService: LeanIXAuthService
     private lateinit var leanIXProperties: LeanIXProperties
     private lateinit var gitHubEnterpriseProperties: GitHubEnterpriseProperties
+    private lateinit var leanIXAuthService: LeanIXAuthService
 
     @BeforeEach
     fun setUp() {
@@ -32,7 +33,14 @@ class WebSocketClientConfigTests {
         stompClient = mockk()
         stompSession = mockk()
         authService = mockk()
-        webSocketClientConfig = WebSocketClientConfig(brokerStompSessionHandler, objectMapper, leanIXProperties)
+        leanIXAuthService = mockk()
+        webSocketClientConfig = WebSocketClientConfig(
+            brokerStompSessionHandler,
+            objectMapper,
+            leanIXAuthService,
+            leanIXProperties,
+            gitHubEnterpriseProperties
+        )
 
         GitHubAgentProperties.GITHUB_AGENT_VERSION = "test-version"
     }
@@ -43,6 +51,7 @@ class WebSocketClientConfigTests {
         coEvery { leanIXProperties.wsBaseUrl } returns "ws://test.url"
         coEvery { gitHubEnterpriseProperties.baseUrl } returns "http://github.enterprise.url"
         coEvery { gitHubEnterpriseProperties.gitHubAppId } returns "appId"
+        coEvery { leanIXAuthService.getBearerToken() } returns "bearer token"
         coEvery {
             stompClient.connectAsync(
                 any<String>(), any<WebSocketHttpHeaders>(),


### PR DESCRIPTION
## 🛠 Changes made
With this PR we limit the maximum attempts on re establishing the websocket connections to 3

## ✨ Type of change
Please delete the options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## 🧪 How Has This Been Tested?
Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [x] Manual tests

## 🏎 Checklist:
- [x] My code follows the style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My commit message clearly reflects the changes made
- [x] Assigned the appropriate labels (version, PR type, etc.)