### PR TITLE
CID-3293: Fix filter of archived repos

### DIFF
--- a/src/main/kotlin/net/leanix/githubagent/services/GitHubScanningService.kt
+++ b/src/main/kotlin/net/leanix/githubagent/services/GitHubScanningService.kt
@@ -86,7 +86,7 @@ class GitHubScanningService(
             )
             webSocketService.sendMessage(
                 "${cachingService.get("runId")}/repositories",
-                repositoriesPage.repositories
+                repositoriesPage.repositories.filter { !it.archived }
             )
             repositories.addAll(repositoriesPage.repositories)
             cursor = repositoriesPage.cursor

--- a/src/main/resources/graphql/GetRepositories.graphql
+++ b/src/main/resources/graphql/GetRepositories.graphql
@@ -1,6 +1,6 @@
 query GetRepositories($pageCount: Int!, $cursor: String) {
     viewer {
-        repositories(isArchived:false, first: $pageCount, after: $cursor) {
+        repositories(first: $pageCount, after: $cursor) {
             pageInfo {
                 endCursor
                 hasNextPage


### PR DESCRIPTION
## 🛠 Changes made
The agent tries to identify manifest files on archived repos, for this we need to filter out archived repositories when fetching repositories on organisations

## ✨ Type of change
Please delete the options that are not relevant.
- [x] Bug fix

## 🧪 How Has This Been Tested?
- [x] No tests required

## 🏎 Checklist:
- [x] I have performed a self-review of my own code
- [x] My commit message clearly reflects the changes made
- [x] Assigned the appropriate labels (version, PR type, etc.)