### PR TITLE
CID-3400 Skip manifest files for archived repositories

### DIFF
--- a/src/main/kotlin/net/leanix/githubagent/services/GitHubScanningService.kt
+++ b/src/main/kotlin/net/leanix/githubagent/services/GitHubScanningService.kt
@@ -122,6 +122,7 @@ class GitHubScanningService(
     }
 
     fun fetchManifestFilesAndSend(installation: Installation, repository: RepositoryDto) {
+        if (repository.archived) return
         val manifestFiles = fetchManifestFiles(installation, repository.name).getOrThrow().items
         val manifestFilesContents = fetchManifestContents(
             installation,

--- a/src/test/kotlin/net/leanix/githubagent/services/GitHubScanningServiceTest.kt
+++ b/src/test/kotlin/net/leanix/githubagent/services/GitHubScanningServiceTest.kt
@@ -230,7 +230,9 @@ class GitHubScanningServiceTest {
         // then
         verify(exactly = 0) { webSocketService.sendMessage(eq("$runId/manifestFiles"), any()) }
         verify(exactly = 0) { syncLogService.sendInfoLog("Scanning repository TestRepo for manifest files.") }
-        verify(exactly = 0) { syncLogService.sendInfoLog("Fetched manifest file 'dir/leanix.yaml' from repository 'TestRepo'.") }
+        verify(
+            exactly = 0
+        ) { syncLogService.sendInfoLog("Fetched manifest file 'dir/leanix.yaml' from repository 'TestRepo'.") }
         verify(exactly = 0) { syncLogService.sendInfoLog("Found 1 manifest files in repository TestRepo.") }
         verify { syncLogService.sendInfoLog("Finished initial full scan for organization testInstallation.") }
         verify { syncLogService.sendInfoLog("Finished full scan for all available organizations.") }


### PR DESCRIPTION
## 🛠 Changes made
This PR ensures that manifests files present in non archived repositories will be fetched

## ✨ Type of change
Please delete the options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## 🧪 How Has This Been Tested?
Please describe the tests that you ran to verify your changes.

- [x] Unit tests

## 🏎 Checklist:
- [x] My code follows the style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My commit message clearly reflects the changes made
- [x] Assigned the appropriate labels (version, PR type, etc.)