### PR TITLE
CID-3590: Skip manifest files with wrong name

### DIFF
--- a/src/main/kotlin/net/leanix/githubagent/services/GitHubScanningService.kt
+++ b/src/main/kotlin/net/leanix/githubagent/services/GitHubScanningService.kt
@@ -156,7 +156,7 @@ class GitHubScanningService(
                     "repo:${installation.account.login}/$repositoryName filename:$MANIFEST_FILE_NAME"
             )
         }
-        manifestFiles.items.filter { it.name == MANIFEST_FILE_NAME }
+        manifestFiles.items.filter { it.name.lowercase() == MANIFEST_FILE_NAME }
     }
     private fun fetchManifestContents(
         installation: Installation,

--- a/src/main/kotlin/net/leanix/githubagent/services/WebhookEventService.kt
+++ b/src/main/kotlin/net/leanix/githubagent/services/WebhookEventService.kt
@@ -110,9 +110,9 @@ class WebhookEventService(
         repositoryName: String,
         installationToken: String
     ) {
-        val addedManifestFiles = headCommit.added.filter { isLeanixManifestFile(it) }
-        val modifiedManifestFiles = headCommit.modified.filter { isLeanixManifestFile(it) }
-        val removedManifestFiles = headCommit.removed.filter { isLeanixManifestFile(it) }
+        val addedManifestFiles = headCommit.added.filter { isLeanixManifestFile(it.lowercase()) }
+        val modifiedManifestFiles = headCommit.modified.filter { isLeanixManifestFile(it.lowercase()) }
+        val removedManifestFiles = headCommit.removed.filter { isLeanixManifestFile(it.lowercase()) }
 
         addedManifestFiles.forEach { filePath ->
             handleAddedOrModifiedManifestFile(

--- a/src/main/kotlin/net/leanix/githubagent/shared/Constants.kt
+++ b/src/main/kotlin/net/leanix/githubagent/shared/Constants.kt
@@ -12,7 +12,7 @@ val SUPPORTED_EVENT_TYPES = listOf(
     "INSTALLATION",
 )
 
-val fileNameMatchRegex = Regex("/?$MANIFEST_FILE_NAME\$")
+val fileNameMatchRegex = Regex("/?$MANIFEST_FILE_NAME\$", RegexOption.IGNORE_CASE)
 
 const val GITHUB_APP_LABEL = "GitHub App"
 const val INSTALLATION_LABEL = "Installation"

--- a/src/test/kotlin/net/leanix/githubagent/services/GitHubScanningServiceTest.kt
+++ b/src/test/kotlin/net/leanix/githubagent/services/GitHubScanningServiceTest.kt
@@ -358,6 +358,78 @@ class GitHubScanningServiceTest {
     }
 
     @Test
+    fun `scanGitHubResources should accept manifest files with case ignored`() {
+        // given
+        every { cachingService.get("runId") } returns runId
+        every { gitHubGraphQLService.getRepositories(any(), any()) } returns PagedRepositories(
+            repositories = listOf(
+                RepositoryDto(
+                    id = "repo1",
+                    name = "TestRepo",
+                    organizationName = "testOrg",
+                    description = "A test repository",
+                    url = "https://github.com/testRepo",
+                    defaultBranch = "main",
+                    archived = false,
+                    visibility = RepositoryVisibility.PUBLIC,
+                    updatedAt = "2024-01-01T00:00:00Z",
+                    languages = listOf("Kotlin", "Java"),
+                    topics = listOf("test", "example"),
+                )
+            ),
+            hasNextPage = false,
+            cursor = null
+        )
+        every { gitHubClient.searchManifestFiles(any(), any()) } returns GitHubSearchResponse(
+            1,
+            listOf(
+                ItemResponse(
+                    name = "leanIX.yaml",
+                    path = "leanIX.yaml",
+                    repository = RepositoryItemResponse(
+                        name = "TestRepo",
+                        fullName = "testOrg/TestRepo"
+                    ),
+                    url = "http://url"
+                ),
+                ItemResponse(
+                    name = "lEAnIX.yaml",
+                    path = "a/lEAnIX.yaml",
+                    repository = RepositoryItemResponse(
+                        name = "TestRepo",
+                        fullName = "testOrg/TestRepo"
+                    ),
+                    url = "http://url"
+                ),
+                ItemResponse(
+                    name = MANIFEST_FILE_NAME,
+                    path = "b/$MANIFEST_FILE_NAME",
+                    repository = RepositoryItemResponse(
+                        name = "TestRepo",
+                        fullName = "testOrg/TestRepo"
+                    ),
+                    url = "http://url"
+                )
+            )
+        )
+        every {
+            gitHubGraphQLService.getManifestFileContent(any(), any(), "b/leanix.yaml", any())
+        } returns "content"
+        every {
+            gitHubGraphQLService.getManifestFileContent(any(), any(), "leanIX.yaml", any())
+        } returns "content"
+        every {
+            gitHubGraphQLService.getManifestFileContent(any(), any(), "a/lEAnIX.yaml", any())
+        } returns "content"
+
+        // when
+        gitHubScanningService.scanGitHubResources()
+
+        // then
+        verify(exactly = 1) { syncLogService.sendInfoLog("Found 3 manifest files in repository TestRepo.") }
+    }
+
+    @Test
     fun `scanGitHubResources should skip organizations without correct permissions and events`() {
         every { cachingService.get("runId") } returns runId
         every { gitHubAPIService.getPaginatedInstallations(any()) } returns listOf(


### PR DESCRIPTION
## 🛠 Changes made
Please explain here the changes you made in this PR.

## ✨ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## 🧪 How Has This Been Tested?
- [x] scanGitHubResources should not send manifest files over WebSocket for manifest files with wrong name
- [x] should not process push event with wrong name

## 🏎 Checklist:
- [x] My commit message clearly reflects the changes made
- [x] Assigned the appropriate labels (version, PR type, etc.)