### PR TITLE
cid-3709: Add socket is connected before send a webhook message

### DIFF
--- a/src/main/kotlin/net/leanix/githubagent/services/GitHubWebhookService.kt
+++ b/src/main/kotlin/net/leanix/githubagent/services/GitHubWebhookService.kt
@@ -13,13 +13,17 @@ import org.springframework.stereotype.Service
 @Service
 class GitHubWebhookService(
     private val webhookEventService: WebhookEventService,
-    private val gitHubEnterpriseProperties: GitHubEnterpriseProperties
+    private val gitHubEnterpriseProperties: GitHubEnterpriseProperties,
+    private val webSocketService: WebSocketService
 ) {
 
     private val logger = LoggerFactory.getLogger(GitHubWebhookService::class.java)
 
     @Async
     fun handleWebhookEvent(eventType: String, host: String, signature256: String?, payload: String) {
+        if (!webSocketService.isConnected()) {
+            return
+        }
         if (SUPPORTED_EVENT_TYPES.contains(eventType.uppercase())) {
             if (!gitHubEnterpriseProperties.baseUrl.contains(host)) {
                 logger.error("Received a webhook event from an unknown host: $host")

--- a/src/main/kotlin/net/leanix/githubagent/services/WebSocketService.kt
+++ b/src/main/kotlin/net/leanix/githubagent/services/WebSocketService.kt
@@ -26,4 +26,6 @@ class WebSocketService(
     fun sendMessage(topic: String, data: Any) {
         stompSession!!.send("$TOPIC_PREFIX$topic", data)
     }
+
+    fun isConnected(): Boolean = stompSession!!.isConnected
 }

--- a/src/test/kotlin/net/leanix/githubagent/controllers/GitHubWebhookControllerTest.kt
+++ b/src/test/kotlin/net/leanix/githubagent/controllers/GitHubWebhookControllerTest.kt
@@ -8,6 +8,7 @@ import net.leanix.githubagent.exceptions.WebhookSecretNotSetException
 import net.leanix.githubagent.services.CachingService
 import net.leanix.githubagent.services.GitHubWebhookService
 import net.leanix.githubagent.services.SyncLogService
+import net.leanix.githubagent.services.WebSocketService
 import net.leanix.githubagent.services.WebhookEventService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -35,11 +36,15 @@ class GitHubWebhookControllerTest {
     @MockkBean
     private lateinit var cachingService: CachingService
 
+    @MockkBean
+    private lateinit var webSocketService: WebSocketService
+
     @BeforeEach
     fun setUp() {
         every { syncLogService.sendErrorLog(any()) } returns Unit
         every { cachingService.get(any()) } returns Unit
         every { cachingService.set(any(), any(), any()) } returns Unit
+        every { webSocketService.isConnected() } returns true
     }
 
     @Test

--- a/src/test/kotlin/net/leanix/githubagent/services/GitHubWebhookServiceTest.kt
+++ b/src/test/kotlin/net/leanix/githubagent/services/GitHubWebhookServiceTest.kt
@@ -14,10 +14,13 @@ class GitHubWebhookServiceTest {
 
     private val webhookEventService = mockk<WebhookEventService>()
     private val gitHubEnterpriseProperties = mockk<GitHubEnterpriseProperties>()
-    private val gitHubWebhookService = GitHubWebhookService(webhookEventService, gitHubEnterpriseProperties)
+    private val webSocketService = mockk<WebSocketService>()
+    private val gitHubWebhookService =
+        GitHubWebhookService(webhookEventService, gitHubEnterpriseProperties, webSocketService)
 
     @BeforeEach
     fun setUp() {
+        every { webSocketService.isConnected() } returns true
     }
 
     @Test


### PR DESCRIPTION
## 🛠 Changes made
Added validation to check if agent is connected to the websocket server before send a message

## ✨ Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## 🧪 How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
- [ ] 👌 Modified tests

## 🏎 Checklist:
- [ ] My code follows the style guidelines
- [ ] I have performed a self-review of my own code
