### PR TITLE
CID-3913: Ignore webhook events if a scan is running

### DIFF
--- a/src/main/kotlin/net/leanix/githubagent/services/GitHubWebhookService.kt
+++ b/src/main/kotlin/net/leanix/githubagent/services/GitHubWebhookService.kt
@@ -13,13 +13,19 @@ import org.springframework.stereotype.Service
 @Service
 class GitHubWebhookService(
     private val webhookEventService: WebhookEventService,
-    private val gitHubEnterpriseProperties: GitHubEnterpriseProperties
+    private val gitHubEnterpriseProperties: GitHubEnterpriseProperties,
+    private val cachingService: CachingService,
 ) {
 
     private val logger = LoggerFactory.getLogger(GitHubWebhookService::class.java)
 
     @Async
     fun handleWebhookEvent(eventType: String, host: String, signature256: String?, payload: String) {
+        val runId = cachingService.get("runId")
+        if (runId != null && eventType.uppercase() != "INSTALLATION") {
+            logger.info("Received a webhook event while a full sync is in progress, ignoring the event.")
+            return
+        }
         if (SUPPORTED_EVENT_TYPES.contains(eventType.uppercase())) {
             if (!gitHubEnterpriseProperties.baseUrl.contains(host)) {
                 logger.error("Received a webhook event from an unknown host: $host")


### PR DESCRIPTION
## 🛠 Changes made
Ignore webhook events if a scan is running

## ✨ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## 🧪 How Has This Been Tested?
- [x] should ignore event when runId is present and event type is not INSTALLATION

## 🏎 Checklist:
- [x] My code follows the style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My commit message clearly reflects the changes made
- [x] Assigned the appropriate labels (version, PR type, etc.)