### PR TITLE
DEVX-773: (AI GENERATED) add explicit permissions to workflow jobs

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -12,6 +12,7 @@ jobs:
   validation:
     name: Branch name validation
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Check branch name
         run: |
@@ -29,6 +30,9 @@ jobs:
     name: Build and test
     needs: validation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/leanix-github-agent-code-coverage.yml
+++ b/.github/workflows/leanix-github-agent-code-coverage.yml
@@ -13,6 +13,10 @@ jobs:
   leanix-github-agent-connector-ci:
     name: Build and test LeanIX GitHub Agent
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Adds minimal required \`permissions:\` blocks to workflow jobs that were missing them.

**Motivation:** Explicit permissions follow the principle of least privilege and prevent accidental access escalation.

**Note:** Please review this PR carefully, as it was generated with assistance from AI. This is only a migration helper, so ensure you thoroughly evaluate the changes before **MERGING IT ON YOUR OWN**.

**Timeline:**
   _From June 1_
   Default switches to read-only org-wide. Repos can still override the setting for their own workflows — giving teams a grace week to finish up.
   _From June 8_
   Read-only is enforced via org policy. No more per-repo override.

**Changes:**
- `gradle-build.yml`: `validation`, `gradle-ci` jobs
- `leanix-github-agent-code-coverage.yml`: `leanix-github-agent-connector-ci` job

**Permissions added:**
- `validation`: `permissions: {}` (no checkout, no actions — no permissions needed)
- `gradle-ci`: `contents: read`, `actions: write` (actions/checkout + gradle/gradle-build-action@v2 with default caching)
- `leanix-github-agent-connector-ci`: `contents: read`, `actions: write`, `pull-requests: write` (actions/checkout + gradle/gradle-build-action@v2 with caching + madrapps/jacoco-report)